### PR TITLE
The Original Link is no longer avariable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
         libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils curl bash \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl http://dl.google.com/linux/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_60.0.3112.7-1_amd64.deb -o /tmp/chrome.deb
+RUN curl dpkg -i google-chrome-stable_current_amd64.deb -o /tmp/chrome.deb
 RUN dpkg -i /tmp/chrome.deb && rm /tmp/chrome.deb
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash


### PR DESCRIPTION
Should work with link to stabile version of chrome instead.